### PR TITLE
feat: bootstrap instance -> e2-medium

### DIFF
--- a/latest/swarm/google/cloud-deployment.yaml
+++ b/latest/swarm/google/cloud-deployment.yaml
@@ -13,7 +13,7 @@ resources:
           subnetwork: us-east1
           seuronImage: ranlu/air-tasks:airflow2
           project: segmentation
-          managerMachineType: e2-standard-2
+          managerMachineType: e2-medium
           composeLocation: https://raw.githubusercontent.com/seung-lab/seuron/airflow2/deploy/docker-compose-CeleryExecutor.yml
           slack:
             botToken: # bot token for slack


### PR DESCRIPTION
Changing the default bootstrap instance type to `e2-medium` as mentioned today in the sync as [assigned](https://app.asana.com/0/1135117027541013/1202140310641078/f) to me.